### PR TITLE
watchman now needs python-dev python-setuptools and fix documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM iojs:2.4.0
 
-RUN apt-get update
-RUN apt-get -y install software-properties-common git-core build-essential automake unzip
+RUN apt-get update && \
+    apt-get -y install software-properties-common git-core build-essential automake unzip python-dev python-setuptools && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/facebook/watchman.git /tmp/watchman
 WORKDIR /tmp/watchman
@@ -13,8 +14,8 @@ RUN make install
 ADD build-package.json /tmp/package.json
 RUN cd /tmp && npm install || true
 RUN mkdir -p /app && cp -a /tmp/node_modules /app/
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN rm -rf /tmp/* /var/tmp/*
+RUN mkdir -p /usr/local/var/run/watchman/
 
 EXPOSE 8081
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 ### React Native docker container for packaging apps
 
-Package your React Native apps with Docker on Ubuntu. Why not?
+Package your React Native apps with Docker on Debian. Why not?
 
 ### Usage
 
 Build:
 
 ```
-% docker build -t rn-packager .
+% sudo ./build -v 0.8.0-rc.2
 ```
 
 Run with a Docker volume where your app javascript lives:
 
 ```
-% docker run -v /path/to/js:/js rn-packager
+% sudo docker run -p 8081:8081 -v /path/to/js:/js packager:0.8.0-rc.2
 ```
+
+The packager is now listening on port 8081.
+
+To access the bundle of your application:
+http://localhost:8081/index.ios.bundle
 
 ### Use in development
 

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,3 +1,4 @@
+set -e
 sudo docker build -t packager .
 sudo docker stop packager
 sudo docker rm packager


### PR DESCRIPTION
install python-dev python-setuptools, now needed to build watchman.
optimize image size by removing /var/lib/apt/lists/\* just after apt-get update/install (in the same docker layer)
watchman needs /usr/local/var/run/watchman/ directory to be there, it tries to save /usr/local/var/run/watchman/root-state

The README says Ubuntu, well it's actually debian, iojs:2.4.0 inherits from buildpack-deps:jessie
and fix instructions how to build and serve.
