### PR TITLE
mount directory to /app/js

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Build:
 Run with a Docker volume where your app javascript lives:
 
 ```
-% sudo docker run -p 8081:8081 -v /path/to/js:/js packager:0.8.0-rc.2
+% sudo docker run -p 8081:8081 -v /path/to/js:/app/js packager:0.8.0-rc.2
 ```
 
 The packager is now listening on port 8081.


### PR DESCRIPTION
mount directory to /app/js instead of /js because now /app is the root.
This now works:
var { Provider, connect } = require('react-redux/native');
it was before saying it couldn't find react-native.
